### PR TITLE
Add more Web Platform Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: node_js
 node_js:
   - '14'
 script:
-  - npm test
-  - npm run build
-  - npm run banner
+  - echo 'Travis has been deprecated for GitHub actions.'
 branches:
   only:
     - master

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,7 +293,7 @@ const CookieStore = {
   async getAll(
     options?: CookieStoreGetOptions['name'] | CookieStoreGetOptions
   ): Promise<Cookie[]> {
-    if (!options) {
+    if (!options || Object.keys(options).length === 0) {
       return parse(document.cookie);
     }
     const { name } = sanitizeOptions<CookieStoreGetOptions>(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,7 +256,9 @@ const CookieStore = {
   async get(
     options?: CookieStoreGetOptions['name'] | CookieStoreGetOptions
   ): Promise<Cookie | undefined> {
-    if (!options || !Object.keys(options).length) {
+    if (options == null) {
+      throw new TypeError('CookieStoreGetOptions must not be empty');
+    } else if (options instanceof Object && !Object.keys(options).length) {
       throw new TypeError('CookieStoreGetOptions must not be empty');
     }
     const { name, url } = sanitizeOptions<CookieStoreGetOptions>(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,10 +166,6 @@ function serialize(
     throw new TypeError('option encode is invalid');
   }
 
-  if (!fieldContentRegExp.test(name)) {
-    throw new TypeError('argument name is invalid');
-  }
-
   const value = enc(val);
 
   if (value && !fieldContentRegExp.test(value)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,15 @@ interface SerializeOptions {
   sameSite?: boolean | string;
 }
 
+interface CookieInit {
+  name: string;
+  value: string;
+  expires?: Date;
+  domain?: string;
+  path: string;
+  sameSite: CookieSameSite;
+}
+
 /**
  * Parse a cookie header.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,8 +296,7 @@ const CookieStore = {
     if (!options || Object.keys(options).length === 0) {
       return parse(document.cookie);
     }
-    const { name } = sanitizeOptions<CookieStoreGetOptions>(options);
-    const cookie = await this.get(name);
+    const cookie = await this.get(options);
     return cookie ? [cookie] : [];
   },
 

--- a/test/wpt-setup/harness.js
+++ b/test/wpt-setup/harness.js
@@ -1,5 +1,11 @@
 /* global assert */
 
+window.test = (fn, name) => {
+  it(name, () => {
+    fn();
+  });
+};
+
 window.promise_test = async (fn, name) => {
   const cleanups = [];
   const testCase = {
@@ -31,3 +37,5 @@ window.promise_rejects_js = async (testCase, expectedError, promise) => {
 };
 
 window.assert_equals = assert.equal;
+window.assert_true = assert.ok;
+window.assert_not_equals = assert.notEqual;

--- a/test/wpt/cookieStore_delete_arguments.tentative.https.any.js
+++ b/test/wpt/cookieStore_delete_arguments.tentative.https.any.js
@@ -1,0 +1,202 @@
+// META: title=Cookie Store API: cookieStore.delete() arguments
+// META: global=window,serviceworker
+
+'use strict';
+
+promise_test(async (testCase) => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+
+  await cookieStore.delete('cookie-name');
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.delete with positional name');
+
+promise_test(async (testCase) => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  await cookieStore.delete({ name: 'cookie-name' });
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.delete with name in options');
+
+promise_test(async (testCase) => {
+  const currentUrl = new URL(self.location.href);
+  const currentDomain = currentUrl.hostname;
+
+  await promise_rejects_js(
+    testCase,
+    TypeError,
+    cookieStore.set({
+      name: 'cookie-name',
+      value: 'cookie-value',
+      domain: `.${currentDomain}`,
+    })
+  );
+}, 'cookieStore.delete domain starts with "."');
+
+promise_test(async (testCase) => {
+  await promise_rejects_js(
+    testCase,
+    TypeError,
+    cookieStore.set({
+      name: 'cookie-name',
+      value: 'cookie-value',
+      domain: 'example.com',
+    })
+  );
+}, 'cookieStore.delete with domain that is not equal current host');
+
+promise_test(async (testCase) => {
+  const currentUrl = new URL(self.location.href);
+  const currentDomain = currentUrl.hostname;
+  await cookieStore.set({
+    name: 'cookie-name',
+    value: 'cookie-value',
+    domain: currentDomain,
+  });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
+  });
+
+  await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.delete with domain set to the current hostname');
+
+promise_test(async (testCase) => {
+  const currentUrl = new URL(self.location.href);
+  const currentDomain = currentUrl.hostname;
+  const subDomain = `sub.${currentDomain}`;
+
+  await promise_rejects_js(
+    testCase,
+    TypeError,
+    cookieStore.delete({ name: 'cookie-name', domain: subDomain })
+  );
+}, 'cookieStore.delete with domain set to a subdomain of the current hostname');
+
+promise_test(async (testCase) => {
+  const currentUrl = new URL(self.location.href);
+  const currentDomain = currentUrl.hostname;
+  assert_not_equals(
+    currentDomain[0] === '.',
+    'this test assumes that the current hostname does not start with .'
+  );
+  const domainSuffix = currentDomain.substr(1);
+
+  await promise_rejects_js(
+    testCase,
+    TypeError,
+    cookieStore.delete({ name: 'cookie-name', domain: domainSuffix })
+  );
+}, 'cookieStore.delete with domain set to a non-domain-matching suffix of ' + 'the current hostname');
+
+promise_test(async (testCase) => {
+  const currentUrl = new URL(self.location.href);
+  const currentPath = currentUrl.pathname;
+  const currentDirectory = currentPath.substr(
+    0,
+    currentPath.lastIndexOf('/') + 1
+  );
+  await cookieStore.set({
+    name: 'cookie-name',
+    value: 'cookie-value',
+    path: currentDirectory,
+  });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
+
+  await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.delete with path set to the current directory');
+
+promise_test(async (testCase) => {
+  const currentUrl = new URL(self.location.href);
+  const currentPath = currentUrl.pathname;
+  const currentDirectory = currentPath.substr(
+    0,
+    currentPath.lastIndexOf('/') + 1
+  );
+  const subDirectory = currentDirectory + 'subdir/';
+  await cookieStore.set({
+    name: 'cookie-name',
+    value: 'cookie-value',
+    path: currentDirectory,
+  });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
+
+  await cookieStore.delete({ name: 'cookie-name', path: subDirectory });
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie.name, 'cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+}, 'cookieStore.delete with path set to subdirectory of the current directory');
+
+promise_test(async (testCase) => {
+  const currentUrl = new URL(self.location.href);
+  const currentPath = currentUrl.pathname;
+  const currentDirectory = currentPath.substr(0, currentPath.lastIndexOf('/'));
+  await cookieStore.set({
+    name: 'cookie-name',
+    value: 'cookie-value',
+    path: currentDirectory + '/',
+  });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
+
+  await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.delete with missing / at the end of path');
+
+promise_test(async (testCase) => {
+  await promise_rejects_js(
+    testCase,
+    TypeError,
+    cookieStore.delete({ name: 'cookie-name', path: 'example/' })
+  );
+}, 'cookieStore.delete with path that does not start with /');
+
+promise_test(async (testCase) => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  const cookie_attributes = await cookieStore.get('cookie-name');
+  assert_equals(cookie_attributes.name, 'cookie-name');
+  assert_equals(cookie_attributes.value, 'cookie-value');
+
+  await cookieStore.delete(cookie_attributes);
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.delete with get result');
+
+promise_test(async (testCase) => {
+  await cookieStore.set('', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('');
+  });
+
+  await cookieStore.delete('');
+  const cookie = await cookieStore.get('');
+  assert_equals(cookie, null);
+}, 'cookieStore.delete with positional empty name');
+
+promise_test(async (testCase) => {
+  await cookieStore.set('', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('');
+  });
+
+  await cookieStore.delete({ name: '' });
+  const cookie = await cookieStore.get('');
+  assert_equals(cookie, null);
+}, 'cookieStore.delete with empty name in options');

--- a/test/wpt/cookieStore_delete_basic.tentative.https.any.js
+++ b/test/wpt/cookieStore_delete_basic.tentative.https.any.js
@@ -1,0 +1,13 @@
+// META: title=Cookie Store API: cookieStore.delete() return type
+// META: global=window,serviceworker
+
+'use strict';
+
+promise_test(async testCase => {
+  const p = cookieStore.delete('cookie-name');
+  assert_true(p instanceof Promise,
+              'cookieStore.delete() returns a promise');
+  const result = await p;
+  assert_equals(result, undefined,
+                'cookieStore.delete() promise resolves to undefined');
+}, 'cookieStore.delete return type is Promise<void>');

--- a/test/wpt/cookieStore_getAll_arguments.tentative.https.any.js
+++ b/test/wpt/cookieStore_getAll_arguments.tentative.https.any.js
@@ -1,0 +1,149 @@
+// META: title=Cookie Store API: cookieStore.getAll() arguments
+// META: global=window,serviceworker
+
+'use strict';
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+  await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name-2');
+  });
+
+  const cookies = await cookieStore.getAll();
+  cookies.sort((a, b) => a.name.localeCompare(b.name));
+  assert_equals(cookies.length, 2);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+  assert_equals(cookies[1].name, 'cookie-name-2');
+  assert_equals(cookies[1].value, 'cookie-value-2');
+}, 'cookieStore.getAll with no arguments');
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+  await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name-2');
+  });
+
+  const cookies = await cookieStore.getAll({});
+  cookies.sort((a, b) => a.name.localeCompare(b.name));
+  assert_equals(cookies.length, 2);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+  assert_equals(cookies[1].name, 'cookie-name-2');
+  assert_equals(cookies[1].value, 'cookie-value-2');
+}, 'cookieStore.getAll with empty options');
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+  await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name-2');
+  });
+
+  const cookies = await cookieStore.getAll('cookie-name');
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+}, 'cookieStore.getAll with positional name');
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+  await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name-2');
+  });
+
+  const cookies = await cookieStore.getAll({ name: 'cookie-name' });
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+}, 'cookieStore.getAll with name in options');
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+  await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name-2');
+  });
+
+  const cookies = await cookieStore.getAll('cookie-name',
+                                           { name: 'wrong-cookie-name' });
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+}, 'cookieStore.getAll with name in both positional arguments and options');
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  let target_url = self.location.href;
+  if (self.GLOBAL.isWorker()) {
+    target_url = target_url + '/path/within/scope';
+  }
+
+  const cookies = await cookieStore.getAll({ url: target_url });
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+}, 'cookieStore.getAll with absolute url in options');
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  let target_path = self.location.pathname;
+  if (self.GLOBAL.isWorker()) {
+    target_path = target_path + '/path/within/scope';
+  }
+
+  const cookies = await cookieStore.getAll({ url: target_path });
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+}, 'cookieStore.getAll with relative url in options');
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  const invalid_url =
+      `${self.location.protocol}//${self.location.host}/different/path`;
+  await promise_rejects_js(testCase, TypeError, cookieStore.getAll(
+      { url: invalid_url }));
+}, 'cookieStore.getAll with invalid url path in options');
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  const invalid_url =
+      `${self.location.protocol}//www.example.com${self.location.pathname}`;
+  await promise_rejects_js(testCase, TypeError, cookieStore.getAll(
+      { url: invalid_url }));
+}, 'cookieStore.getAll with invalid url host in options');

--- a/test/wpt/cookieStore_getAll_multiple.tentative.https.any.js
+++ b/test/wpt/cookieStore_getAll_multiple.tentative.https.any.js
@@ -1,0 +1,29 @@
+// META: title=Cookie Store API: cookieStore.getAll() with multiple cookies
+// META: global=window,serviceworker
+
+'use strict';
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+  await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name-2');
+  });
+  await cookieStore.set('cookie-name-3', 'cookie-value-3');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name-3');
+  });
+
+  const cookies = await cookieStore.getAll();
+  cookies.sort((a, b) => a.name.localeCompare(b.name));
+  assert_equals(cookies.length, 3);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+  assert_equals(cookies[1].name, 'cookie-name-2');
+  assert_equals(cookies[1].value, 'cookie-value-2');
+  assert_equals(cookies[2].name, 'cookie-name-3');
+  assert_equals(cookies[2].value, 'cookie-value-3');
+}, 'cookieStore.getAll returns multiple cookies written by cookieStore.set');

--- a/test/wpt/cookieStore_getAll_set_basic.tentative.https.any.js
+++ b/test/wpt/cookieStore_getAll_set_basic.tentative.https.any.js
@@ -1,0 +1,16 @@
+// META: title=Cookie Store API: Interaction between cookieStore.set() and cookieStore.getAll()
+// META: global=window,serviceworker
+
+'use strict';
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+  const cookies = await cookieStore.getAll('cookie-name');
+
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+}, 'cookieStore.getAll returns the cookie written by cookieStore.set');

--- a/test/wpt/cookieStore_get_arguments.tentative.https.any.js
+++ b/test/wpt/cookieStore_get_arguments.tentative.https.any.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-promise_test(async (testCase) => {
+promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
   testCase.add_cleanup(async () => {
     await cookieStore.delete('cookie-name');
@@ -12,16 +12,16 @@ promise_test(async (testCase) => {
   await promise_rejects_js(testCase, TypeError, cookieStore.get());
 }, 'cookieStore.get with no arguments returns TypeError');
 
-promise_test(async (testCase) => {
+promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
   testCase.add_cleanup(async () => {
     await cookieStore.delete('cookie-name');
   });
 
   await promise_rejects_js(testCase, TypeError, cookieStore.get({}));
-}, 'cookieStore.get with empty options returns TypeError');
+},'cookieStore.get with empty options returns TypeError');
 
-promise_test(async (testCase) => {
+promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
   testCase.add_cleanup(async () => {
     await cookieStore.delete('cookie-name');
@@ -32,7 +32,7 @@ promise_test(async (testCase) => {
   assert_equals(cookie.value, 'cookie-value');
 }, 'cookieStore.get with positional name');
 
-promise_test(async (testCase) => {
+promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
   testCase.add_cleanup(async () => {
     await cookieStore.delete('cookie-name');
@@ -43,20 +43,19 @@ promise_test(async (testCase) => {
   assert_equals(cookie.value, 'cookie-value');
 }, 'cookieStore.get with name in options');
 
-promise_test(async (testCase) => {
+promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
   testCase.add_cleanup(async () => {
     await cookieStore.delete('cookie-name');
   });
 
-  const cookie = await cookieStore.get('cookie-name', {
-    name: 'wrong-cookie-name',
-  });
+  const cookie = await cookieStore.get('cookie-name',
+                                       { name: 'wrong-cookie-name' });
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
 }, 'cookieStore.get with name in both positional arguments and options');
 
-promise_test(async (testCase) => {
+promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
   testCase.add_cleanup(async () => {
     await cookieStore.delete('cookie-name');
@@ -72,7 +71,7 @@ promise_test(async (testCase) => {
   assert_equals(cookie.value, 'cookie-value');
 }, 'cookieStore.get with absolute url in options');
 
-promise_test(async (testCase) => {
+promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
   testCase.add_cleanup(async () => {
     await cookieStore.delete('cookie-name');
@@ -88,20 +87,16 @@ promise_test(async (testCase) => {
   assert_equals(cookie.value, 'cookie-value');
 }, 'cookieStore.get with relative url in options');
 
-promise_test(async (testCase) => {
-  const invalid_url = `${self.location.protocol}//${self.location.host}/different/path`;
-  await promise_rejects_js(
-    testCase,
-    TypeError,
-    cookieStore.get({ url: invalid_url })
-  );
+promise_test(async testCase => {
+  const invalid_url =
+      `${self.location.protocol}//${self.location.host}/different/path`;
+  await promise_rejects_js(testCase, TypeError, cookieStore.get(
+      { url: invalid_url }));
 }, 'cookieStore.get with invalid url path in options');
 
-promise_test(async (testCase) => {
-  const invalid_url = `${self.location.protocol}//www.example.com${self.location.pathname}`;
-  await promise_rejects_js(
-    testCase,
-    TypeError,
-    cookieStore.get({ url: invalid_url })
-  );
+promise_test(async testCase => {
+  const invalid_url =
+      `${self.location.protocol}//www.example.com${self.location.pathname}`;
+  await promise_rejects_js(testCase, TypeError, cookieStore.get(
+      { url: invalid_url }));
 }, 'cookieStore.get with invalid url host in options');

--- a/test/wpt/cookieStore_get_delete_basic.tentative.https.any.js
+++ b/test/wpt/cookieStore_get_delete_basic.tentative.https.any.js
@@ -1,0 +1,14 @@
+// META: title=Cookie Store API: Interaction between cookieStore.set() and cookieStore.delete()
+// META: global=window,serviceworker
+
+'use strict';
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+     await cookieStore.delete('cookie-name');
+  });
+  await cookieStore.delete('cookie-name');
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.get returns null for a cookie deleted by cookieStore.delete');

--- a/test/wpt/cookieStore_get_set_across_frames.tentative.https.html
+++ b/test/wpt/cookieStore_get_set_across_frames.tentative.https.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<meta charset='utf-8'>
+<title>Async Cookies: cookieStore basic API across frames</title>
+<link rel='help' href='https://github.com/WICG/cookie-store'>
+<link rel='author' href='jarrydg@chromium.org' title='Jarryd Goodman'>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<style>iframe { display: none; }</style>
+<iframe id='iframe'></iframe>
+<script>
+'use strict';
+
+promise_test(async t => {
+  const iframe = document.getElementById('iframe');
+  const frameCookieStore = iframe.contentWindow.cookieStore;
+
+  const oldCookie = await frameCookieStore.get('cookie-name');
+  assert_equals(oldCookie, null,
+      'Precondition not met: cookie store should be empty');
+
+  await cookieStore.set('cookie-name', 'cookie-value');
+  t.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  const frameCookie = await frameCookieStore.get('cookie-name');
+  assert_equals(frameCookie.value, 'cookie-value');
+}, 'cookieStore.get() sees cookieStore.set() in frame');
+
+promise_test(async t => {
+  const iframe = document.getElementById('iframe');
+  const frameCookieStore = iframe.contentWindow.cookieStore;
+
+  const oldCookie = await frameCookieStore.get('cookie-name');
+  assert_equals(oldCookie, null,
+      'Precondition not met: cookie store should be empty');
+
+  await frameCookieStore.set('cookie-name', 'cookie-value');
+  t.add_cleanup(async () => {
+    await frameCookieStore.delete('cookie-name');
+  });
+
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+}, 'cookieStore.get() in frame sees cookieStore.set()')
+</script>

--- a/test/wpt/cookieStore_get_set_across_origins.tentative.sub.https.html
+++ b/test/wpt/cookieStore_get_set_across_origins.tentative.sub.https.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<meta charset='utf-8'>
+<title>Async Cookies: cookieStore basic API across origins</title>
+<link rel='help' href='https://github.com/WICG/cookie-store'>
+<link rel='author' href='jarrydg@chromium.org' title='Jarryd Goodman'>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='resources/helpers.js'></script>
+<style>iframe { display: none; }</style>
+
+<script>
+'use strict';
+
+const kPath = '/cookie-store/resources/helper_iframe.sub.html';
+const kCorsBase = `https://{{domains[www1]}}:{{ports[https][0]}}`;
+const kCorsUrl = `${kCorsBase}${kPath}`;
+
+promise_test(async t => {
+  const iframe = await createIframe(kCorsUrl, t);
+  assert_true(iframe != null);
+
+  iframe.contentWindow.postMessage({
+    opname: 'set-cookie',
+    name: 'cookie-name',
+    value: 'cookie-value',
+  }, kCorsBase);
+  t.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', domain: '{{host}}' });
+  });
+  await waitForMessage();
+
+  const cookies = await cookieStore.getAll();
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+}, 'cookieStore.get() sees cookieStore.set() in cross-origin frame');
+
+promise_test(async t => {
+  const iframe = await createIframe(kCorsUrl, t);
+  assert_true(iframe != null);
+
+  await cookieStore.set({
+    name: 'cookie-name',
+    value: 'cookie-value',
+    domain: '{{host}}',
+  });
+
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+
+  iframe.contentWindow.postMessage({
+    opname: 'get-cookie',
+    name: 'cookie-name',
+  }, kCorsBase);
+  t.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', domain: '{{host}}' });
+  });
+
+  const message = await waitForMessage();
+
+  const { frameCookie } = message;
+  assert_not_equals(frameCookie, null);
+  assert_equals(frameCookie.name, 'cookie-name');
+  assert_equals(frameCookie.value, 'cookie-value');
+}, 'cookieStore.get() in cross-origin frame sees cookieStore.set()');
+</script>

--- a/test/wpt/cookieStore_get_set_basic.tentative.https.any.js
+++ b/test/wpt/cookieStore_get_set_basic.tentative.https.any.js
@@ -1,0 +1,15 @@
+// META: title=Cookie Store API: Interaction between cookieStore.set() and cookieStore.get()
+// META: global=window,serviceworker
+
+'use strict';
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+  const cookie = await cookieStore.get('cookie-name');
+
+  assert_equals(cookie.name, 'cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+}, 'cookieStore.get returns the cookie written by cookieStore.set');

--- a/test/wpt/cookieStore_get_set_ordering.tentative.https.any.js
+++ b/test/wpt/cookieStore_get_set_ordering.tentative.https.any.js
@@ -1,0 +1,42 @@
+// META: title=Cookie Store API: Cookie ordering
+// META: global=window,serviceworker
+
+'use strict';
+
+promise_test(async t => {
+  await cookieStore.set('ordered-1', 'cookie-value1');
+  await cookieStore.set('ordered-2', 'cookie-value2');
+  await cookieStore.set('ordered-3', 'cookie-value3');
+  // NOTE: this assumes no concurrent writes from elsewhere; it also
+  // uses three separate cookie jar read operations where a single getAll
+  // would be more efficient, but this way the CookieStore does the filtering
+  // for us.
+  const matchingValues = await Promise.all(['1', '2', '3'].map(
+      async suffix => (await cookieStore.get('ordered-' + suffix)).value));
+  const actual = matchingValues.join(';');
+  const expected = 'cookie-value1;cookie-value2;cookie-value3';
+  assert_equals(actual, expected);
+}, 'Set three simple origin session cookies sequentially and ensure ' +
+            'they all end up in the cookie jar in order.');
+
+promise_test(async t => {
+  await Promise.all([
+    cookieStore.set('ordered-unordered1', 'unordered-cookie-value1'),
+    cookieStore.set('ordered-unordered2', 'unordered-cookie-value2'),
+    cookieStore.set('ordered-unordered3', 'unordered-cookie-value3')
+  ]);
+  // NOTE: this assumes no concurrent writes from elsewhere; it also
+  // uses three separate cookie jar read operations where a single getAll
+  // would be more efficient, but this way the CookieStore does the filtering
+  // for us and we do not need to sort.
+  const matchingCookies = await Promise.all(['1', '2', '3'].map(
+    suffix => cookieStore.get('ordered-unordered' + suffix)));
+  const actual = matchingCookies.map(({ value }) => value).join(';');
+  const expected =
+      'unordered-cookie-value1;' +
+      'unordered-cookie-value2;' +
+      'unordered-cookie-value3';
+  assert_equals(actual, expected);
+}, 'Set three simple origin session cookies in undefined order using ' +
+            'Promise.all and ensure they all end up in the cookie jar in any ' +
+            'order. ');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2018",
     "module": "esnext",
     "strict": true,
     "noImplicitThis": true,


### PR DESCRIPTION
Add some WPT tests for `.get`, `.delete` and `.set`. Had to do some slight refactoring to get the tests to pass. Looking at individual commits makes this easier to review.

Follow-up PRs will make the tests a build artifact rather than keeping them in source control.