### PR TITLE
fix typo in workflow name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
-name: Node.js Package
+name: Node.js Build
 
 on: [push, pull_request]
     


### PR DESCRIPTION
This fixes `buld` -> `build` :laughing: 