### PR TITLE
Limit dependabot to security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
+    allowed_updates:
+      - match:
+          update_type: 'security'


### PR DESCRIPTION
This updates the dependabot configuration to only open PRs to upgrade dependencies with security vulnerabilities. This will save time from having to keep closing (postponing) dependabot PRs while much of the repo is still a work in progress.

Resolves #111  