### PR TITLE
refactor: change CookieSameSite to be an enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,6 @@ function tryDecode(
   }
 }
 
-type CookieSameSite = 'none' | 'lax' | 'strict';
 type CookieMatchType = 'equals';
 
 interface Cookie {
@@ -74,6 +73,12 @@ interface SerializeOptions {
   httpOnly?: boolean;
   secure?: boolean;
   sameSite?: boolean | string;
+}
+
+enum CookieSameSite {
+  strict = 'strict',
+  lax = 'lax',
+  none = 'none',
 }
 
 interface CookieInit {
@@ -331,7 +336,7 @@ const CookieStore: CookieStore = {
       value: '',
       path: '/',
       secure: false,
-      sameSite: 'strict',
+      sameSite: CookieSameSite.strict,
     };
     if (typeof init === 'string') {
       item.name = init as string;


### PR DESCRIPTION
This changes the `CookieSameSite` type to be an `enum`, which allows us to be more consistent when using the SameSite value across the codebase.

/cc @markcellus @koddsson 