### PR TITLE
refactor: turn CookieStore into a proper class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -265,20 +265,6 @@ function sanitizeOptions<T>(arg: string | T): T {
   return arg;
 }
 
-interface CookieStore {
-  get(
-    options?: CookieStoreGetOptions['name'] | CookieStoreGetOptions
-  ): Promise<Cookie | undefined>;
-  onchange(event: CookieChangeEvent): void;
-  set(options: CookieInit | string, value?: string): Promise<void>;
-  getAll(
-    options?: CookieStoreGetOptions['name'] | CookieStoreGetOptions
-  ): Promise<Cookie[]>;
-  delete(
-    options: CookieStoreDeleteOptions['name'] | CookieStoreDeleteOptions
-  ): Promise<void>;
-}
-
 class CookieChangeEvent extends Event {
   changed: CookieList;
   deleted: CookieList;
@@ -293,7 +279,18 @@ class CookieChangeEvent extends Event {
   }
 }
 
-const CookieStore: CookieStore = {
+class CookieStore extends EventTarget {
+  onchange?: (event: CookieChangeEvent) => void;
+
+  get [Symbol.toStringTag]() {
+    return 'CookieStore';
+  }
+
+  constructor() {
+    super();
+    throw new TypeError('Illegal Constructor');
+  }
+
   /**
    * Get a cookie.
    *
@@ -320,10 +317,7 @@ const CookieStore: CookieStore = {
       return parse(document.cookie)[0];
     }
     return parse(document.cookie).find((cookie) => cookie.name === name);
-  },
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onchange() {},
+  }
 
   async set(init: CookieInit | string, possibleValue?: string): Promise<void> {
     const item: CookieListItem = {
@@ -349,10 +343,11 @@ const CookieStore: CookieStore = {
 
     const cookieString = serialize(item.name, item.value, item);
     document.cookie = cookieString;
-    this.onchange(
-      new CookieChangeEvent('change', { changed: [item], deleted: [] })
-    );
-  },
+    if (this.onchange)
+      this.onchange(
+        new CookieChangeEvent('change', { changed: [item], deleted: [] })
+      );
+  }
 
   /**
    * Get multiple cookies.
@@ -365,7 +360,7 @@ const CookieStore: CookieStore = {
     }
     const cookie = await this.get(options);
     return cookie ? [cookie] : [];
-  },
+  }
 
   /**
    * Remove a cookie.
@@ -404,26 +399,29 @@ const CookieStore: CookieStore = {
       });
       document.cookie = serializedValue;
     }
-    this.onchange(
-      new CookieChangeEvent('change', {
-        changed: [],
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        deleted: [{ ...results, value: undefined }],
-      })
-    );
+    if (this.onchange)
+      this.onchange(
+        new CookieChangeEvent('change', {
+          changed: [],
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          deleted: [{ ...results, value: undefined }],
+        })
+      );
     return Promise.resolve();
-  },
-};
+  }
+}
 
 if (!window.cookieStore) {
-  window.cookieStore = CookieStore;
+  window.CookieStore = CookieStore;
+  window.cookieStore = Object.create(CookieStore.prototype);
   window.CookieChangeEvent = CookieChangeEvent;
 }
 
 declare global {
   interface Window {
-    cookieStore: typeof CookieStore;
+    CookieStore: typeof CookieStore;
+    cookieStore: CookieStore;
     CookieChangeEvent: typeof CookieChangeEvent;
   }
 }

--- a/test/index.tests.js
+++ b/test/index.tests.js
@@ -10,6 +10,23 @@ describe('Cookie Store', () => {
   afterEach(() => {
     document.cookie = '';
   });
+
+  it('is a class, instanceof CookieStore', () => {
+    expect(window.cookieStore).to.be.instanceof(window.CookieStore)
+  })
+
+  it('is an instanceof EventTarget', () => {
+    expect(window.cookieStore).to.be.instanceof(window.EventTarget)
+  })
+
+  it('has a toStringTag of CookieStore', () => {
+    expect(window.cookieStore[Symbol.toStringTag]).to.equal('CookieStore')
+  })
+
+  it('cannot be constructed', () => {
+    expect(() => new window.CookieStore()).to.throw(TypeError, 'Illegal')
+  })
+
   describe('get', () => {
     it('returns cookie matching supplied name', async () => {
       const foo = 'foo';


### PR DESCRIPTION
This changes CookieStore to be a class, that extends from `EventTarget`. The class constructor is exposed on the `window` object such that one can assert `cookieStore instanceof CookieStore`. Calling `new CookieStore()` however will throw a TypeError, as per spec (and behaviour confirmed in Chrome 88). 

This changes will allow us to dispatch the `change` event in addition to calling the `onchange` function, which is an integral part of the `CookieStore`.

Refs #46 

/cc @markcellus @koddsson 