### PR TITLE
build: delete travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - '14'
-script:
-  - echo 'Travis has been deprecated for GitHub actions.'
-branches:
-  only:
-    - master


### PR DESCRIPTION
This deletes the travis.yml file. We no longer have a desire to build using Travis.

@markcellus the Travis build is marked as `required` - you'll need to go into `Settings` -> `Branches` -> Click `Edit` on `master` -> and uncheck `Travis CI - Pull Request` from the list in "Require status checks to pass before merging". 

It might also be worth _adding_ `Node.js Build / build (pull_request)` to the list of required status checks.