### PR TITLE
Run tests on foo.bar.localhost hostname

### DIFF
--- a/test/karma.conf.cjs
+++ b/test/karma.conf.cjs
@@ -18,5 +18,6 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     browsers: ['FirefoxHeadless'],
     concurrency: Infinity,
+    hostname: 'foo.bar.localhost',
   });
 };


### PR DESCRIPTION
I was working on some domain cookie tests and ran into this snag where you have to have two periods in the hostname for the domain to be considered.

>Only hosts within the specified domain can set a cookie for a domain and domains must have at least two (2) or three (3) periods in them to prevent domains of the form: ".com", ".edu", and "va.us". Any domain that fails within one of the seven special top level domains listed below only require two periods. Any other domain requires at least three. The seven special top level domains are: "COM", "EDU", "NET", "ORG", "GOV", "MIL", and "INT".

-- https://curl.se/rfc/cookie_spec.html

A version of this constraint is also mentioned in [RFC6265](https://tools.ietf.org/html/rfc6265#section-5.2.3):

>  If the user agent is configured to reject "public suffixes" and
>  the domain-attribute is a public suffix:
>
>  If the domain-attribute is identical to the canonicalized
>  request-host:
>
>    Let the domain-attribute be the empty string.
>
>  Otherwise:
>
>    Ignore the cookie entirely and abort these steps.
>
>  NOTE: A "public suffix" is a domain that is controlled by a
>  public registry, such as "com", "co.uk", and "pvt.k12.wy.us".
>  This step is essential for preventing attacker.com from
>  disrupting the integrity of example.com by setting a cookie
>  with a Domain attribute of "com".  Unfortunately, the set of
>  public suffixes (also known as "registry controlled domains")
>  changes over time.  If feasible, user agents SHOULD use an
>  up-to-date public suffix list, such as the one maintained by
>  the Mozilla project at <http://publicsuffix.org/>.

By running the tests on a subdomain of `localhost` we can avoid this problem.

