### PR TITLE
Delete dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: monthly
-    allowed_updates:
-      - match:
-          update_type: 'security'


### PR DESCRIPTION
The Dependabot configuration file was invalid so this removes it entirely--we don't need it. This, in effect, still achieves the same goal as in #113.