### PR TITLE
Add disclaimer for API limitations of latest npm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,18 @@
 
 A speculative polyfill to allow use of the [Cookie Store API](https://wicg.github.io/cookie-store/) in modern browsers that don't support it natively, including IE11. Also compatible with TypeScript.
 
-⚠️ **Experimental warning:** the Cookie Store API is not a W3C standard yet and the final implementation may differ from the current API of this polyfill.
+:warning: **EXPERIMENTAL:** _The Cookie Store API is not a W3C standard yet and the final implementation may differ from the current API of this polyfill._
 
 ## Installation
 
 ```sh
 npm install cookie-store
+```
+
+Or, if you prefer to use an upcoming version of the package with more features (and closer to the final specification). Install the latest `next` version of the package. See the README on the [`next` branch](https://github.com/markcellus/cookie-store/tree/next) for the updated API.
+
+```
+npm install cookie-store@next
 ```
 
 ## Basic Example


### PR DESCRIPTION
The latest npm version of the project (3.0) offers a limited API and has falling out of sync with the latest version of the CookieStore specification.

So this adds a small disclaimer to the README on master branch to clearly set expectations for consumers and to ensure they know that we're working on a more updated version of the package on the `next` branch.

Resolves #132 