### PR TITLE
Update paths to JS file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "cookie esm"
   ],
   "type": "module",
-  "module": "index.js",
-  "types": "index.d.ts",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "repository": "markcellus/cookie-store",
   "devDependencies": {
     "@types/chai": "^4.2.14",


### PR DESCRIPTION
Since the published module (on npm) ships everything in the `dist` folder, the relevant entries in `package.json` should point into that folder. Otherwise Node's resolve algorithm will fail to import the ES modules. 

E.g. I use rollup with `@rollup/plugin-node-resolve` for bundling.